### PR TITLE
fix: use the image name from the meta output in the vulnerability sca…

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ inputs.vulnerability-scan-run }}
         uses: crazy-max/ghaction-container-scan@v4
         with:
-          image: ${{ inputs.docker-registry }}/${{ inputs.docker-image-owner }}/${{ inputs.docker-image-name }}
+          image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           dockerfile: ${{ inputs.build-context }}/${{ inputs.build-dockerfile }}
           annotations: true
           severity_threshold: ${{ inputs.vulnerability-scan-threshold }}


### PR DESCRIPTION
…nner

otherwise if the repository name is used as the image name and contains a uppercase letter this action will fail