### PR TITLE
feat!(deploy): add option to merge two folders during deployment

### DIFF
--- a/.github/actions/deploy/ReadMe.md
+++ b/.github/actions/deploy/ReadMe.md
@@ -2,6 +2,38 @@
 
 Deploy a Compose Project and rebuild the containers.
 
+## Deploy a whole directory
+
+### Folder Structure
+
+```
+.
+└── Deployment/
+    ├── Production/
+    │   ├── compose.yml
+    │   └── .env
+    ├── Staging/
+    │   ├── compose.yml
+    │   └── .env
+    └── Testing/
+        ├── compose.yml
+        └── .env
+```
+
+### Example Files
+
+```yaml
+# Deployment/Production/compose.yml
+
+services:
+  php: []
+  nginx: []
+  # ...
+```
+
+
+### Job Definition
+
 ```yaml
 name: Deploy
 
@@ -22,10 +54,95 @@ jobs:
         with:
           version: ${{ github.ref_type == 'tag' && github.ref_name || needs.prepare.outputs.short_sha }}
           ref-type: ${{ github.ref_type }}
-          deployment-compose-source: ${{ vars.DEPLOYMENT_COMPOSE_SOURCE }}
-          deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }}
+          deployment-compose-source: ${{ vars.DEPLOYMENT_COMPOSE_SOURCE }} # => ./Deployment/Production
+          deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }} # => /docker/deployment/foo-project
           deployment-environment-env-filename: ${{ vars.ENV_FILENAME }} # => .foo-project.env
           # deployment-compose-do-upgrade: true
+          # deployment-force-recreate-containers: ${{ vars.DEPLOYMENT_COMPOSE_FORCE_RECREATE_CONTAINERS }}
+          # backup-do-backup: ${{ vars.DEPLOYMENT_COMPOSE_DO_BACKUP }}
+          # backup-target-folder: ${{ vars.DEPLOYMENT_COMPOSE_BACKUP_TARGET_FOLDER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+          SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+```
+
+
+## Deploy and merge two directories
+
+If you have a base directory with all services and a second directory with every environment, use this job definition instead.
+
+### Folder Structure
+
+```
+.
+└── Deployment/
+    ├── Base/
+    │   └── lib/
+    │       ├── compose.base.yml
+    │       ├── compose.cronjob.a.yml
+    │       └── compose.cronjob.b.yml
+    ├── Production/
+    │   ├── compose.yml
+    │   └── .env
+    ├── Staging/
+    │   ├── compose.yml
+    │   └── .env
+    └── Testing/
+        ├── lib/
+        │   └── compose.cronjob.a.yml
+        ├── compose.yml
+        └── .env
+```
+
+The file `Deployment/Testing/lib/compose.cronjob.a.yml` will override the file from `./Deployment/Base/lib/compose.cronjob.a.yml` during the deployment.
+
+
+### Example Files
+
+```yaml
+# Deployment/Base/lib/compose.base.yml
+
+services:
+  php: []
+  nginx: []
+  # ...
+```
+
+```yaml
+# Deployment/Production/compose.yml
+
+includes:
+  - ./lib/compose.base.yml
+```
+
+### Job Definition
+
+```yaml
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target Environment"
+        required: true
+        type: environment
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: avency/gh-workflows/.github/actions/deploy@main
+        with:
+          version: ${{ github.ref_type == 'tag' && github.ref_name || needs.prepare.outputs.short_sha }}
+          ref-type: ${{ github.ref_type }}
+          deployment-compose-source: ${{ vars.DEPLOYMENT_COMPOSE_SOURCE }} # => ./Deployment/Base
+          deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }} # => /docker/deployment/foo-project
+          deployment-environment-source: ${{ vars.DEPLOYMENT_COMPOSE_ENVIRONMENT_SOURCE }} # => ./Deployment/Production
+          deployment-environment-env-filename: '' # not needed, put the env file as .env into the environment folder
+          deployment-compose-do-upgrade: true
           # deployment-force-recreate-containers: ${{ vars.DEPLOYMENT_COMPOSE_FORCE_RECREATE_CONTAINERS }}
           # backup-do-backup: ${{ vars.DEPLOYMENT_COMPOSE_DO_BACKUP }}
           # backup-target-folder: ${{ vars.DEPLOYMENT_COMPOSE_BACKUP_TARGET_FOLDER }}

--- a/.github/actions/deploy/ReadMe.md
+++ b/.github/actions/deploy/ReadMe.md
@@ -24,7 +24,7 @@ jobs:
           ref-type: ${{ github.ref_type }}
           deployment-compose-source: ${{ vars.DEPLOYMENT_COMPOSE_SOURCE }}
           deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }}
-          env-filename: ${{ vars.ENV_FILENAME }}
+          deployment-environment-env-filename: ${{ vars.ENV_FILENAME }} # => .foo-project.env
           # deployment-compose-do-upgrade: true
           # backup-do-backup: ${{ vars.DEPLOYMENT_COMPOSE_DO_BACKUP }}
           # backup-target-folder: ${{ vars.DEPLOYMENT_COMPOSE_BACKUP_TARGET_FOLDER }}

--- a/.github/actions/deploy/ReadMe.md
+++ b/.github/actions/deploy/ReadMe.md
@@ -26,6 +26,7 @@ jobs:
           deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }}
           deployment-environment-env-filename: ${{ vars.ENV_FILENAME }} # => .foo-project.env
           # deployment-compose-do-upgrade: true
+          # deployment-force-recreate-containers: ${{ vars.DEPLOYMENT_COMPOSE_FORCE_RECREATE_CONTAINERS }}
           # backup-do-backup: ${{ vars.DEPLOYMENT_COMPOSE_DO_BACKUP }}
           # backup-target-folder: ${{ vars.DEPLOYMENT_COMPOSE_BACKUP_TARGET_FOLDER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Whether to upgrade the deployment"
     required: true
     default: 'true'
+  deployment-environment-source:
+    description: "Source path for the environment deployment"
+    required: false
+    default: ''
   deployment-environment-env-filename:
     description: "Name of the .env file to symlink"
     required: false
@@ -89,6 +93,18 @@ runs:
         remote_key: ${{ inputs.SSH_KEY }}
         remote_path: ${{ inputs.deployment-compose-target }}
         path: ${{ inputs.deployment-compose-source }}
+
+    - name: Copy environment deployment files to host
+      if: ${{ inputs.deployment-environment-source != '' }}
+      uses: burnett01/rsync-deployments@8.0.4
+      with:
+        switches: "-avzr"
+        remote_host: ${{ inputs.SSH_HOST }}
+        remote_port: ${{ inputs.SSH_PORT }}
+        remote_user: ${{ inputs.SSH_USERNAME }}
+        remote_key: ${{ inputs.SSH_KEY }}
+        remote_path: ${{ inputs.deployment-compose-target }}
+        path: ${{ inputs.deployment-environment-source }}/
 
     - name: Symlink .env file
       uses: appleboy/ssh-action@v1.2.5

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: "Whether to upgrade the deployment"
     required: true
     default: 'true'
-  env-filename:
+  deployment-environment-env-filename:
     description: "Name of the .env file to symlink"
     required: false
     default: ''
@@ -88,7 +88,7 @@ runs:
 
     - name: Symlink .env file
       uses: appleboy/ssh-action@v1.2.5
-      if: ${{ inputs.env-filename != '' }}
+      if: ${{ inputs.deployment-environment-env-filename != '' }}
       with:
         host: ${{ inputs.SSH_HOST }}
         username: ${{ inputs.SSH_USERNAME }}
@@ -96,7 +96,7 @@ runs:
         port: ${{ inputs.SSH_PORT }}
         script: |
           cd ${{ inputs.deployment-compose-target }}/
-          ln -sfn ${{ inputs.env-filename }} .env
+          ln -sfn ${{ inputs.deployment-environment-env-filename }} .env
 
     - name: 'Upgrade 1: Override the VERSION variable with the branch name'
       # Run for branches (or when ref-type not set). Skip for tags so .env VERSION is not overwritten.

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Name of the .env file to symlink"
     required: false
     default: ''
+  deployment-force-recreate-containers:
+    description: "A list of containers to force recreate"
+    required: false
+    default: ''
 
   # backup
   backup-do-backup:
@@ -153,5 +157,9 @@ runs:
         timeout: "600s"
         script: |
           cd ${{ inputs.deployment-compose-target }}/
-          docker compose up -d --force-recreate redis
+
+          if [ -n "${{ inputs.deployment-force-recreate-containers }}" ]; then
+            docker compose up -d --force-recreate ${{ inputs.deployment-force-recreate-containers }}
+          fi
+
           docker compose up -d --remove-orphans

--- a/.github/workflows/deploy-neos.yml
+++ b/.github/workflows/deploy-neos.yml
@@ -55,7 +55,7 @@ jobs:
           ref-type: ${{ github.ref_type }}
           deployment-compose-source: ${{ vars.DEPLOYMENT_COMPOSE_SOURCE }}
           deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }}
-          env-filename: ${{ vars.ENV_FILENAME }}
+          deployment-environment-env-filename: ${{ vars.ENV_FILENAME }}
           deployment-compose-do-upgrade: true
           backup-do-backup: ${{ vars.DEPLOYMENT_COMPOSE_DO_BACKUP }}
           backup-target-folder: ${{ vars.DEPLOYMENT_COMPOSE_BACKUP_TARGET_FOLDER }}

--- a/.github/workflows/deploy-neos.yml
+++ b/.github/workflows/deploy-neos.yml
@@ -55,6 +55,7 @@ jobs:
           ref-type: ${{ github.ref_type }}
           deployment-compose-source: ${{ vars.DEPLOYMENT_COMPOSE_SOURCE }}
           deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }}
+          deployment-environment-source: ${{ vars.DEPLOYMENT_COMPOSE_ENVIRONMENT_SOURCE }}
           deployment-environment-env-filename: ${{ vars.ENV_FILENAME }}
           deployment-compose-do-upgrade: true
           deployment-force-recreate-containers: ${{ vars.DEPLOYMENT_COMPOSE_FORCE_RECREATE_CONTAINERS }}

--- a/.github/workflows/deploy-neos.yml
+++ b/.github/workflows/deploy-neos.yml
@@ -57,6 +57,7 @@ jobs:
           deployment-compose-target: ${{ vars.DEPLOYMENT_COMPOSE_TARGET }}
           deployment-environment-env-filename: ${{ vars.ENV_FILENAME }}
           deployment-compose-do-upgrade: true
+          deployment-force-recreate-containers: ${{ vars.DEPLOYMENT_COMPOSE_FORCE_RECREATE_CONTAINERS }}
           backup-do-backup: ${{ vars.DEPLOYMENT_COMPOSE_DO_BACKUP }}
           backup-target-folder: ${{ vars.DEPLOYMENT_COMPOSE_BACKUP_TARGET_FOLDER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -129,7 +129,7 @@ jobs:
 
 ### deploy
 
-Deploy a Compose Project and rebuild the containers.
+Deploy a Compose Project and rebuild the containers. It is possible to merge two folders during the deployment.
 
 [Read more](./.github/actions/deploy/ReadMe.md)
 


### PR DESCRIPTION
## feat!(deploy): rename env-filename input

## feat!(deploy): remove default force-recreation of redis 

add a variable to recreate specific containers instead.

Create a new variable `DEPLOYMENT_COMPOSE_FORCE_RECREATE_CONTAINERS` with "redis" as the content


## feat!(deploy): add option to merge two folders during deployment 

It is now possible to create a base directory with all service definitions and a different directory for every environment that only overides or extends specific service definitions.